### PR TITLE
fix time_left option's behaviour

### DIFF
--- a/Rapfi/command/gomocup.cpp
+++ b/Rapfi/command/gomocup.cpp
@@ -203,7 +203,11 @@ void getOption()
             options.timeLimit = false;
     }
     else if (token == "TIME_LEFT") {
-        std::cin >> options.timeLeft;
+        std::cin >> val;
+        if (val == 2147483647)  // unlimited match time specificed in the protocol
+            options.timeLeft = std::numeric_limits<Time>::max();
+        else
+            options.timeLeft = val;
     }
     else if (token == "MAX_MEMORY") {
         std::cin >> val;

--- a/Rapfi/search/timecontrol.cpp
+++ b/Rapfi/search/timecontrol.cpp
@@ -59,8 +59,6 @@ void TimeControl::init(Time turnTime, Time matchTime, Time matchTimeLeft, MovePa
 {
     startTime = now();
 
-    if (matchTime <= 0)  // unlimited match time
-        matchTimeLeft = std::numeric_limits<Time>::max();
     float movesToGo = std::max(params.movesLeft, 1);
     maximumTime     = Time(matchTimeLeft / std::min(Config::MatchSpaceMin, movesToGo));
     maximumTime     = std::max(std::min(turnTime, maximumTime) - Config::TurnTimeReserved, (Time)0);


### PR DESCRIPTION
Now it strictly follows the piskvork protocol: "The remaining time can be negative when the brain runs out of time. Remaining time is equal to 2147483647 if the time for a whole match is unlimited." [skip_fishtest]